### PR TITLE
Added units config to allow output of values in US or Metric units

### DIFF
--- a/bin/user/zabbix.py
+++ b/bin/user/zabbix.py
@@ -29,6 +29,7 @@ import os
 import weeutil.weeutil
 import weewx.engine
 import weewx.units
+import weewx
 
 from subprocess import Popen, PIPE, STDOUT
 
@@ -57,20 +58,34 @@ class Zabbix(weewx.engine.StdService):
         self.prefix = conf.get('prefix', 'weewx_')
         self.server = conf.get('server', '127.0.0.1')
         self.host = conf.get('host', 'weewx-host')
+        if conf.has_key('units'):
+            if conf['units'] == "US":
+                self.unit_system = weewx.US
+            if conf['units'] == "METRIC":
+                self.unit_system = weewx.METRIC
+            if conf['units'] == "METRICWX":
+               self.unit_system = weewx.METRICWX
+        else:
+            self.unit_system = None
 
         logdbg("self.enable=" + str(self.enable))
         logdbg("self.zabbix_sender=" + self.zabbix_sender)
         logdbg("self.prefix=" + self.prefix)
         logdbg("self.server=" + self.server)
         logdbg("self.host=" + self.host)
+        logdbg("self.unit_system=" + str(self.unit_system))
 
         if self.enable:
 	        self.bind(weewx.NEW_LOOP_PACKET, self.loop)
 
     def loop(self, event):
 	logdbg("loop data:")
+        targetUnits = self.unit_system
+        if targetUnits is None:
+            targetUnits = event.packet['usUnits']
+        convertedPacket = weewx.units.to_std_system(event.packet, targetUnits)
         s = ""
-        for key,value in event.packet.items():
+        for key,value in convertedPacket.items():
             l=self.host + " " + self.prefix+key + " " + str(value) + "\n"
             s+=l
 	    logdbg(l)

--- a/install.py
+++ b/install.py
@@ -44,6 +44,7 @@ class ZabbixInstaller(ExtensionInstaller):
                     'prefix': 'weewx_',
                     'server': '127.0.0.1',
                     'host': 'weewx-host',
+                    'units': 'US',
                 },
             },
             files=[('bin/user', ['bin/user/zabbix.py'])]


### PR DESCRIPTION
Output to Zabbix can be configured for US, METRIC or METRICWX units.

i.e.
[ZABBIX]
    enable = true
    zabbix_sender = /usr/bin/zabbix_sender
    prefix = weewx_
    server = 127.0.0.1
    host = host
    units = METRIC

Code changes based off OpsGenie extension https://github.com/weewx/weewx/wiki/opsgenie
