### PR TITLE
new send_interval config setting

### DIFF
--- a/bin/user/zabbix.py
+++ b/bin/user/zabbix.py
@@ -24,6 +24,7 @@
 #############################################################################
 
 from datetime import datetime
+import time
 import os
 
 import weeutil.weeutil
@@ -57,18 +58,24 @@ class Zabbix(weewx.engine.StdService):
         self.prefix = conf.get('prefix', 'weewx_')
         self.server = conf.get('server', '127.0.0.1')
         self.host = conf.get('host', 'weewx-host')
+        self.send_interval = conf.get('send_interval', None)
 
         logdbg("self.enable=" + str(self.enable))
         logdbg("self.zabbix_sender=" + self.zabbix_sender)
         logdbg("self.prefix=" + self.prefix)
         logdbg("self.server=" + self.server)
         logdbg("self.host=" + self.host)
+        logdbg("self.send_interval=" + self.send_interval)
 
         if self.enable:
 	        self.bind(weewx.NEW_LOOP_PACKET, self.loop)
 
     def loop(self, event):
 	logdbg("loop data:")
+        if self.send_interval != None && last_time != None && time.time() - last_time < self.send_interval:
+            logdbg("Ignoring packet")
+            return
+        last_time = time.time()
         s = ""
         for key,value in event.packet.items():
             l=self.host + " " + self.prefix+key + " " + str(value) + "\n"

--- a/bin/user/zabbix.py
+++ b/bin/user/zabbix.py
@@ -29,7 +29,6 @@ import os
 import weeutil.weeutil
 import weewx.engine
 import weewx.units
-import weewx
 
 from subprocess import Popen, PIPE, STDOUT
 
@@ -58,34 +57,20 @@ class Zabbix(weewx.engine.StdService):
         self.prefix = conf.get('prefix', 'weewx_')
         self.server = conf.get('server', '127.0.0.1')
         self.host = conf.get('host', 'weewx-host')
-        if conf.has_key('units'):
-            if conf['units'] == "US":
-                self.unit_system = weewx.US
-            if conf['units'] == "METRIC":
-                self.unit_system = weewx.METRIC
-            if conf['units'] == "METRICWX":
-               self.unit_system = weewx.METRICWX
-        else:
-            self.unit_system = None
 
         logdbg("self.enable=" + str(self.enable))
         logdbg("self.zabbix_sender=" + self.zabbix_sender)
         logdbg("self.prefix=" + self.prefix)
         logdbg("self.server=" + self.server)
         logdbg("self.host=" + self.host)
-        logdbg("self.unit_system=" + str(self.unit_system))
 
         if self.enable:
 	        self.bind(weewx.NEW_LOOP_PACKET, self.loop)
 
     def loop(self, event):
 	logdbg("loop data:")
-        targetUnits = self.unit_system
-        if targetUnits is None:
-            targetUnits = event.packet['usUnits']
-        convertedPacket = weewx.units.to_std_system(event.packet, targetUnits)
         s = ""
-        for key,value in convertedPacket.items():
+        for key,value in event.packet.items():
             l=self.host + " " + self.prefix+key + " " + str(value) + "\n"
             s+=l
 	    logdbg(l)

--- a/bin/user/zabbix.py
+++ b/bin/user/zabbix.py
@@ -29,6 +29,7 @@ import os
 import weeutil.weeutil
 import weewx.engine
 import weewx.units
+import weewx
 
 from subprocess import Popen, PIPE, STDOUT
 
@@ -57,20 +58,34 @@ class Zabbix(weewx.engine.StdService):
         self.prefix = conf.get('prefix', 'weewx_')
         self.server = conf.get('server', '127.0.0.1')
         self.host = conf.get('host', 'weewx-host')
+        if conf.has_key('units'):
+            if conf['units'] == "US":
+                self.unit_system = weewx.US
+            if conf['units'] == "METRIC":
+                self.unit_system = weewx.METRIC
+            if conf['units'] == "METRICWX":
+               self.unit_system = weewx.METRICWX
+        else:
+            self.unit_system = None
 
         logdbg("self.enable=" + str(self.enable))
         logdbg("self.zabbix_sender=" + self.zabbix_sender)
         logdbg("self.prefix=" + self.prefix)
         logdbg("self.server=" + self.server)
         logdbg("self.host=" + self.host)
+        logdbg("self.unit_system=" + str(self.unit_system))
 
         if self.enable:
 	        self.bind(weewx.NEW_LOOP_PACKET, self.loop)
 
     def loop(self, event):
 	logdbg("loop data:")
+        targetUnits = self.unit_system
+        if targetUnits is None:
+            targetUnits = event.packet['usUnits']
+        convertedPacket = weewx.units.to_std_system(event.packet, targetUnits)
         s = ""
-        for key,value in event.packet.items():
+        for key,value in convertedPacket.items():
             l=self.host + " " + self.prefix+key + " " + str(value) + "\n"
             s+=l
 	    logdbg(l)

--- a/bin/user/zabbix.py
+++ b/bin/user/zabbix.py
@@ -58,24 +58,26 @@ class Zabbix(weewx.engine.StdService):
         self.prefix = conf.get('prefix', 'weewx_')
         self.server = conf.get('server', '127.0.0.1')
         self.host = conf.get('host', 'weewx-host')
-        self.send_interval = conf.get('send_interval', None)
+        self.send_interval = float(conf.get('send_interval', 0))
+
+        self.last_time = None
 
         logdbg("self.enable=" + str(self.enable))
         logdbg("self.zabbix_sender=" + self.zabbix_sender)
         logdbg("self.prefix=" + self.prefix)
         logdbg("self.server=" + self.server)
         logdbg("self.host=" + self.host)
-        logdbg("self.send_interval=" + self.send_interval)
+        logdbg("self.send_interval=" + str(self.send_interval))
 
         if self.enable:
 	        self.bind(weewx.NEW_LOOP_PACKET, self.loop)
 
     def loop(self, event):
 	logdbg("loop data:")
-        if self.send_interval != None && last_time != None && time.time() - last_time < self.send_interval:
-            logdbg("Ignoring packet")
+        if self.send_interval > 0 and self.last_time != None and time.time() - self.last_time < self.send_interval:
+            logdbg("Ignoring packet. Next update in " + str(self.send_interval - (time.time() - self.last_time)) + "s")
             return
-        last_time = time.time()
+        self.last_time = time.time()
         s = ""
         for key,value in event.packet.items():
             l=self.host + " " + self.prefix+key + " " + str(value) + "\n"

--- a/install.py
+++ b/install.py
@@ -44,6 +44,7 @@ class ZabbixInstaller(ExtensionInstaller):
                     'prefix': 'weewx_',
                     'server': '127.0.0.1',
                     'host': 'weewx-host',
+                    'units': 'US',
                 },
             },
             files=[('bin/user', ['bin/user/zabbix.py'])]

--- a/install.py
+++ b/install.py
@@ -44,6 +44,7 @@ class ZabbixInstaller(ExtensionInstaller):
                     'prefix': 'weewx_',
                     'server': '127.0.0.1',
                     'host': 'weewx-host',
+                    'send_interval': '0'
                 },
             },
             files=[('bin/user', ['bin/user/zabbix.py'])]

--- a/install.py
+++ b/install.py
@@ -44,7 +44,6 @@ class ZabbixInstaller(ExtensionInstaller):
                     'prefix': 'weewx_',
                     'server': '127.0.0.1',
                     'host': 'weewx-host',
-                    'units': 'US',
                 },
             },
             files=[('bin/user', ['bin/user/zabbix.py'])]


### PR DESCRIPTION
New config item to call zabbix_sender only once every send_interval seconds. Some weather stations have updates every second (i.e. Davis Vantage) which is way to much data to send to zabbix. Just throw most updates away

Config item
send_update = 0 to disable (default)
send_update = 60 to update zabbix every minute
